### PR TITLE
fix:Wire resample 16khz into AudioRecorder stop recording

### DIFF
--- a/mofa-macos-ime/third_party/mofa-input/src/asr/audio.rs
+++ b/mofa-macos-ime/third_party/mofa-input/src/asr/audio.rs
@@ -7,6 +7,7 @@ pub struct AudioRecorder {
     samples: Arc<Mutex<Vec<f32>>>,
     stream: Option<Box<dyn StreamTrait>>,
     is_recording: Arc<Mutex<bool>>,
+    sample_rate: u32,
 }
 
 impl AudioRecorder {
@@ -15,6 +16,7 @@ impl AudioRecorder {
             samples: Arc::new(Mutex::new(Vec::new())),
             stream: None,
             is_recording: Arc::new(Mutex::new(false)),
+            sample_rate: 16000,
         }
     }
 
@@ -63,12 +65,7 @@ impl AudioRecorder {
 
         stream.play()?;
         self.stream = Some(Box::new(stream));
-
-        // Resample to 16kHz if needed
-        if sample_rate != 16000 {
-            // Store original sample rate for later resampling
-            // For now, we'll resample after stopping
-        }
+        self.sample_rate = sample_rate;
 
         Ok(())
     }
@@ -79,7 +76,7 @@ impl AudioRecorder {
         self.stream = None;
 
         let samples = self.samples.lock().unwrap().clone();
-        // TODO: Resample to 16kHz if needed
+        let samples = resample_to_16khz(&samples, self.sample_rate);
         Ok(samples)
     }
 


### PR DESCRIPTION

Closes #3 

## Problem

`AudioRecorder::stop_recording()` claims to return "16kHz, mono, f32" audio
samples but never actually performs resampling. On Apple Silicon Macs, the
default microphone records at 48kHz. Feeding these raw samples to Whisper
(which expects exactly 16kHz) causes: incorrect transcriptions, garbled
output, or silent failures.

The `resample_to_16khz()` function already existed in the same file
(lines 92–114) but was never called.

## Changes

**File:** `third_party/mofa-input/src/asr/audio.rs`

- Added `sample_rate: u32` field to `AudioRecorder` struct
- Store device sample rate from `cpal` config in `start_recording()`
- Call `resample_to_16khz()` in `stop_recording()` before returning samples
- Removed empty placeholder `if` block and `TODO` comment

